### PR TITLE
scrobble the last item in the playlist

### DIFF
--- a/mpdscrobble/__main__.py
+++ b/mpdscrobble/__main__.py
@@ -37,6 +37,12 @@ def loop(
                         else:
                             logger.warning("Dry-run mode enabled.")
                     networks.mpdscrobble_update_now_playing(current_song)
+            if not current_song and cached_song:
+                if cached_song.percentage > constants.SCROBBLE_PERCENTAGE:
+                    if not args.dry_run:
+                        networks.mpdscrobble_scrobble(cached_song)
+                    else:
+                        logger.warning("Dry-run mode enabled")
             cached_song = client.mpdscrobble_currentsong()
     except Exception as e:
         logger.error(e)


### PR DESCRIPTION
Using MoOde player i noticed the last item in the playlist doesnt get scrobbled.  This is due to current_song = None and cached_song = {last_item_in_playlist}.  There was no condition to handle this so the scrobble never goes through.  This fixes that in my testing.