### PR TITLE
Maintenance: modernize tooling, fix mpdscribble_history import bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,20 +12,24 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest pytest-cov pylast python-mpd2
-        python setup.py install
+        pip install pytest pytest-cov httpx python-mpd2 pylast
+        pip install -e .
     - name: Test with pytest
       run: |
-        pytest --cov=./
-    - uses: codecov/codecov-action@v1
+        pytest --cov=./ --cov-report=xml -v
+    - uses: codecov/codecov-action@v5
+      with:
+        files: ./coverage.xml
+        fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ mpdscrobble.conf
 .idea/
 .direnv/
 venv/
+.venv/
+.pytest_cache/
+.coverage
+coverage.xml
+*.pyc
+*.pyo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,21 +2,21 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v5.0.0
   hooks:
     - id: trailing-whitespace
     - id: end-of-file-fixer
     - id: check-yaml
     - id: check-added-large-files
 - repo: https://github.com/psf/black
-  rev: 23.3.0
+  rev: 25.1.0
   hooks:
     - id: black
-      language_version: python3.11
+      language_version: python3.13
 - repo: https://github.com/pycqa/flake8
-  rev: 6.0.0
+  rev: 7.1.1
   hooks:
     - id: flake8
-      language_version: python3.11
+      language_version: python3.13
       additional_dependencies:
         - flake8-bugbear

--- a/mpdscribble_history.py
+++ b/mpdscribble_history.py
@@ -5,12 +5,9 @@ import logging
 import argparse
 from mpdscrobble.utils import (
     read_config,
-    create_network,
+    create_networks,
 )
-from mpdscrobble.mpdscrobble import (
-    MPDScrobbleMPDConnection,
-    MPDScrobbleTrack,
-)
+from mpdscrobble.mpdscrobble import MPDScrobbleMPDConnection, MPDScrobbleTrack
 
 
 logger = logging.getLogger()
@@ -50,7 +47,7 @@ def main():
     mpdscribble_journal = read_journal(args.journal_file)
     config = read_config(args.config_file)
 
-    networks = create_network(config)
+    networks = create_networks(config)
 
     host = DEFAULT_HOST
     port = DEFAULT_PORT

--- a/mpdscrobble/__init__.py
+++ b/mpdscrobble/__init__.py
@@ -1,10 +1,5 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 """
 A simple Last.fm scrobbler for MPD.
 """
 
 __version__ = "0.3.3"
-
-name = "mpdscrobble"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,40 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mpdscrobble"
+version = "0.3.3"
+description = "A simple Last.fm scrobbler for MPD."
+readme = "README.md"
+license = {text = "MIT"}
+authors = [
+    {name = "dbeley", email = "dbeley@protonmail.com"},
+]
+requires-python = ">=3.9"
+keywords = ["mpd", "last.fm", "scrobbler", "scrobble", "listenbrainz", "maloja"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Operating System :: POSIX :: Linux",
+]
+
+dependencies = [
+    "httpx>=0.28.0",
+    "python-mpd2>=3.0.0",
+    "pylast>=5.0.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/dbeley/mpdscrobble"
+Repository = "https://github.com/dbeley/mpdscrobble"
+
+[project.scripts]
+mpdscrobble = "mpdscrobble.__main__:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,3 @@
-import setuptools
-import mpdscrobble
+from setuptools import setup
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
-
-setuptools.setup(
-    name="mpdscrobble",
-    version=mpdscrobble.__version__,
-    author="dbeley",
-    author_email="dbeley@protonmail.com",
-    description="A simple Last.fm scrobbler for MPD.",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/dbeley/mpdscrobble",
-    packages=setuptools.find_packages(),
-    include_package_data=True,
-    entry_points={"console_scripts": ["mpdscrobble=mpdscrobble.__main__:main"]},
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "Operating System :: POSIX :: Linux",
-    ],
-    install_requires=["httpx", "python-mpd2", "pylast"],
-)
+setup()

--- a/shell.nix
+++ b/shell.nix
@@ -1,17 +1,18 @@
-with import <nixpkgs> { };
+{
+  pkgs ? import <nixpkgs> { },
+}:
+
 pkgs.mkShell {
-  buildInputs = [
+  buildInputs = with pkgs; [
     python3
-    python3Packages.pip
-    pipenv
-
-    python3Packages.mpd2
-    python3Packages.pylast
-    python3Packages.httpx
-    python3Packages.twine
-    python3Packages.pytest
-
     pre-commit
   ];
 
+  shellHook = ''
+    if [ ! -d .venv ]; then
+      python3 -m venv .venv
+    fi
+    source .venv/bin/activate
+    pip install -e . 2>/dev/null || true
+  '';
 }


### PR DESCRIPTION
## Summary

This PR brings several maintenance updates to the project:

### Bug Fix
- **mpdscribble_history.py**: Fixed import `create_network` → `create_networks` (the function was renamed in `utils.py` but the import in `mpdscribble_history.py` was not updated, causing an `ImportError` at runtime).

### Project Modernization
- **pyproject.toml**: Migrated project metadata from `setup.py` to the modern `[project]` section (name, version, dependencies, classifiers, scripts, URLs). Added `[tool.pytest.ini_options]` for test discovery.
- **setup.py**: Reduced to a minimal single-line `setup()` call, deferring all metadata to `pyproject.toml`.
- **Dependencies**: Added minimum version bounds (`httpx>=0.28.0`, `python-mpd2>=3.0.0`, `pylast>=5.0.0`). Bumped requires-python to `>=3.9`.

### CI & Tooling
- **CI**: Updated `actions/checkout` v2→v4, `actions/setup-python` v2→v5, `codecov-action` v1→v5. Removed EOL Python 3.7/3.8, added 3.12/3.13.
- **Pre-commit**: Updated `pre-commit-hooks` v4.5.0→v5.0.0, `black` 23.3.0→25.1.0, `flake8` 6.0.0→7.1.1.
- **shell.nix**: Replaced `pipenv`-based shell with modern venv-based approach.
- **`__init__.py`**: Removed unnecessary shebang, encoding declaration, and unused `name` variable.

### Testing
All 8 existing tests pass with the updated configuration.